### PR TITLE
Buck build support

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -1,0 +1,5 @@
+[project]
+  ignore = .git, .buckd
+
+[cxx]
+  cxxflags = -std=c++14

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.buckd/
+/buck-out/
+.buckconfig.local

--- a/BUCK
+++ b/BUCK
@@ -1,0 +1,26 @@
+linux_linker_flags = [
+  '-lpthread',
+]
+
+cxx_library(
+  name = 'reuzel',
+  header_namespace = '',
+  exported_headers = subdir_glob([
+    ('src', '**/*.h'),
+  ], prefix = 'Reuzel'),
+  headers = subdir_glob([
+    ('src', '**/*.h'),
+  ]),
+  srcs = glob([
+    'src/**/*.cpp',
+  ]),
+  platform_linker_flags = [
+    ('^linux.*', linux_linker_flags),
+  ],
+  licenses = [
+    'LICENSE',
+  ],
+  visibility = [
+    'PUBLIC',
+  ],
+)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ if you want to run the test example:
     ./Reuzel
 
 
+### Building with Buck
+
+Reuzel can also be built using [Buck](https://buckbuild.com): 
+
+```
+buck build :reuzel
+```
+
+To run the test example:
+
+```
+buck run test/
+```
+
 ## Basic Usage
 
 1. Include the header file in your source file:`#include "ThreadPool.h"`

--- a/buckaroo.json
+++ b/buckaroo.json
@@ -1,0 +1,4 @@
+{
+  "name": "reuzel",
+  "target": "reuzel"
+}

--- a/test/BUCK
+++ b/test/BUCK
@@ -1,0 +1,9 @@
+cxx_binary(
+  name = 'test',
+  srcs = [
+    'test.cpp',
+  ],
+  deps = [
+    '//:reuzel',
+  ],
+)


### PR DESCRIPTION
This PR adds support for builds using [Buck](https://buckbuild.com/).

To build the library:

```
buck build :reuzel
```

To run the tests:

```
buck run test/
```

The existing Make build is unchanged; the two can coexist peacefully 😊